### PR TITLE
메시지 모듈 server-side 방식 http에서 socket으로 변경했습니다.

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,12 +15,14 @@ app.set('view engine', 'jade');
 app.set('views', 'html');
 
 //routing
-let message = require('./router/message')(app);
+let message = require('./router/message')(express);
 app.use('/song/message',message);
 
 // socket.io
-let io = require('socket.io').listen(80)
+let server = require('http').createServer()
+let io = require('socket.io')(server)
 require('./socket.io/message')(io.sockets)
+io.listen(3001)
 
 let db = mongoose.connection;
 db.on('error', console.error);

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-let express = require('express')
+let express = require('express');
 let urlencode = require('urlencode');
 let request = require('request');
 let cheerio = require('cheerio');
@@ -17,6 +17,10 @@ app.set('views', 'html');
 //routing
 let message = require('./router/message')(app);
 app.use('/song/message',message);
+
+// socket.io
+let io = require('socket.io').listen(80)
+require('./socket.io/message')(io.sockets)
 
 let db = mongoose.connection;
 db.on('error', console.error);

--- a/html/index.jade
+++ b/html/index.jade
@@ -213,4 +213,5 @@ html(lang='en')
           b(style='cursor:pointer;' onclick='window.open("https://github.com/Kitchu0401")') kitchu
 
   // include message module
-  include module/message-socket-io
+  include module/message-http
+  // include module/message-socket-io

--- a/html/index.jade
+++ b/html/index.jade
@@ -213,4 +213,4 @@ html(lang='en')
           b(style='cursor:pointer;' onclick='window.open("https://github.com/Kitchu0401")') kitchu
 
   // include message module
-  include module/message
+  include module/message-socket-io

--- a/html/message.jade
+++ b/html/message.jade
@@ -1,1 +1,0 @@
-//- Message Code Here //

--- a/html/module/message-http.jade
+++ b/html/module/message-http.jade
@@ -85,7 +85,7 @@ div#messageSidebar(data-open='false', data-message-count='0')
         html += '<li>'
         html += '<h6>' + seqStr + message.writer + ' ' + '<small>' + message.formattedDate + '</small></h6>'
         html += '<small class="content">' + message.content + '</small>'
-        html += '<li>'
+        html += '</li>'
         return html
       }))
 

--- a/html/module/message-http.jade
+++ b/html/module/message-http.jade
@@ -16,7 +16,6 @@ div#messageSidebar(data-open='false', data-message-count='0')
     ul#messageList
   div.messageSidebarCurtain(onclick='toggleNav()')
 
-  script(src='https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.1/socket.io.js')
   script.
 
     // 메시지 목록 토글 스타일
@@ -25,52 +24,16 @@ div#messageSidebar(data-open='false', data-message-count='0')
       close: { 'width': '0' }
     }
 
-    var __service = {
-      
-      http: function () {
-        return {
-
-          sendMessage: function (message, callback) {
-            // validate
-            if ( !message ) { return }
-            if ( message.content.length <= 0 ) { return }
-          
-            $('#messageForm').find('input[name=content]').val('')
-            var messageCount = $('#messageSidebar').data('message-count')
-            $.post(url + '/message', message, callback)
-          },
-
-          loadMessage: function (messageCount, callback) {
-            var messageCount = $('#messageSidebar').data('message-count')
-            $.getJSON(url + '/message/' + messageCount, callback)
-          }
-
-        }
-      }
-
-    }
-
     // puclic function
     //  - 모듈 최초 로드시 호출된다.
     $(function () {
       // 부모 문서에서 특정 속성을 가진 요소에 이벤트를 바인딩한다.
       $('body').find('*[data-role="toggle-message-sidebar"]').on('click', toggleNav)
 
-      __service = __service.http
-
       // Initialization
       resize()
       loadMessage()
     })
-    
-    function initConnection () {
-      var socket = io('http://localhost')
-
-      socket.on('welcome', function(data) {
-        console.log(data)
-        socket.emit('sendMessage', { message: 'How are you?' })
-      })
-    }
 
     // puclic function
     //  - 메시지 목록을 열거나 닫는다.

--- a/html/module/message-socket-io.jade
+++ b/html/module/message-socket-io.jade
@@ -1,0 +1,129 @@
+div#messageSidebar(data-open='false', data-last-seq='0')
+  div.messageSidebar
+    form#messageForm(onsubmit='return false')
+      div.row
+        div.col-xs-4
+          input.form-control.input-sm(type='text' name='writer' placeholder='Anonymous')
+        div.col-xs-8
+          div.input-group
+            input.form-control.input-sm(type='text' name='content' onkeydown='if ( event.which === 13 ) { sendMessage() }')
+            span.input-group-btn
+              button.btn.btn-default.btn-sm(type='button' onclick='sendMessage()') Send
+    ul#messageList
+    button#moreBtn.btn.btn-default(style='display: none; margin: 6px;' onclick='requestMoreMessage()') More
+  div.messageSidebarCurtain(onclick='toggleNav()')
+
+  script(src='https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.1/socket.io.js')
+  script.
+
+    // [DEBUG] 메시지 내 seq 표시 여부
+    var showSeq = true
+
+    // 전역 socket 객체
+    var socket
+
+    // 메시지 목록 토글 스타일
+    var messageSidebarStyle = {
+      show: { 'width': '80%', 'max-width': '640px' },
+      hide: { 'width': '0' }
+    }
+
+    // 메시지 추가 조회 버튼 토글 스타일
+    var moreBtnStyle = {
+      show: { display: 'inline-block' },
+      hide: { display: 'none' }
+    }
+
+    // puclic function
+    //  - 모듈 최초 로드시 호출된다.
+    $(function () {
+      // 부모 문서에서 특정 속성을 가진 요소에 이벤트를 바인딩한다.
+      $('body').find('*[data-role="toggle-message-sidebar"]').on('click', toggleNav)
+
+      // Initialization
+      resize()
+      initConnection()
+    })
+
+    // puclic function
+    //  - 메시지 목록을 열거나 닫는다.
+    function toggleNav () {
+      var isOpen = Boolean($('#messageSidebar').data('open'))
+      $('#messageSidebar')
+        .data('open', !isOpen)
+        .find('.messageSidebar')
+        .css(isOpen ? messageSidebarStyle.hide : messageSidebarStyle.show)
+        .end()
+        .find('.messageSidebarCurtain')
+        .css(isOpen ? { width: '0' } : { width: '100%' })
+    }
+
+    // init function
+    //  - socket 커넥션을 생성하고 전역 이벤트를 할당한다.
+    function initConnection () {
+      // root socket object
+      socket = io('http://localhost:3001')
+      
+      // recieve initialization data
+      socket.on('fetchMessage', _renderResult)
+      
+      // recieve initialization data
+      socket.on('newMessage', _renderNewMessage)
+    }
+
+    // service function
+    //  - 메시지를 전송한다.
+    function sendMessage (message) {
+      var writer = $('#messageForm').find('input[name=writer]').val().trim() || 'Anonymous'
+      var content = $('#messageForm').find('input[name=content]').val().trim()
+
+      // validate
+      if ( content.length <= 0 ) { return }
+
+      socket.emit('sendMessage', { writer: writer, content: content })
+    }
+
+    // service function
+    //  - 메시지를 조회한다.
+    function requestMoreMessage () {
+      var lastSeq = $('#messageSidebar').data('last-seq')
+      socket.emit('requestMessage', lastSeq)
+    }
+
+    // private function
+    //  - 조회된 메시지를 출력한다.
+    function _renderResult (result) {
+      // 재조회를 위해 마지막 메시지의 seq를 저장한다.
+      var listLength = result.messageList.length
+      var lastSeq = listLength > 0 ? result.messageList[listLength - 1].seq : -1
+      $('#messageSidebar').data('last-seq', lastSeq)
+
+      // 조회된 메시지를 메시지 목록 하단에 출력한다.
+      result.messageList.forEach(function (message) {
+        var seqStr = showSeq ? '[' + message.seq + '] ' : ''
+        var html = ''
+            html += '<li class="message" data-seq="' + message.seq + '">'
+            html += '<h6>' + seqStr + message.writer + ' ' + '<small>' + message.formattedDate + '</small></h6>'
+            html += '<small class="content">' + message.content + '</small>'
+            html += '<li>'
+        $('#messageList').append(html)
+      })
+
+      // 조회된 메시지보다 많은 숫자의 메시지가 존재할 경우, 추가 조회를 위한 버튼을 출력한다.
+      var currentCount = $('#messageList').find('li.message').length
+      console.log(currentCount, result.totalCount)
+      $('#moreBtn').css(currentCount < result.totalCount ? moreBtnStyle.show : moreBtnStyle.hide)
+    }
+
+    // private function
+    //  - 새롭게 등록된 메시지를 출력한다.
+    function _renderNewMessage (message) {
+      // 등록된 메시지를 메시지 목록 상단에 출력한다.
+      var seqStr = showSeq ? '[' + message.seq + '] ' : ''
+      var html = ''
+          html += '<li class="message" data-seq="' + message.seq + '">'
+          html += '<h6>' + seqStr + message.writer + ' ' + '<small>' + message.formattedDate + '</small></h6>'
+          html += '<small class="content">' + message.content + '</small>'
+          html += '<li>'
+      $('#messageList').prepend(html)
+    }

--- a/html/module/message-socket-io.jade
+++ b/html/module/message-socket-io.jade
@@ -123,6 +123,6 @@ div#messageSidebar(data-open='false', data-last-seq='0')
           html += '<li class="message" data-seq="' + message.seq + '">'
           html += '<h6>' + seqStr + message.writer + ' ' + '<small>' + message.formattedDate + '</small></h6>'
           html += '<small class="content">' + message.content + '</small>'
-          html += '<li>'
+          html += '</li>'
       $('#messageList').prepend(html)
     }

--- a/html/module/message-socket-io.jade
+++ b/html/module/message-socket-io.jade
@@ -111,7 +111,6 @@ div#messageSidebar(data-open='false', data-last-seq='0')
 
       // 조회된 메시지보다 많은 숫자의 메시지가 존재할 경우, 추가 조회를 위한 버튼을 출력한다.
       var currentCount = $('#messageList').find('li.message').length
-      console.log(currentCount, result.totalCount)
       $('#moreBtn').css(currentCount < result.totalCount ? moreBtnStyle.show : moreBtnStyle.hide)
     }
 

--- a/html/module/message.jade
+++ b/html/module/message.jade
@@ -15,7 +15,8 @@ div#messageSidebar(data-open='false', data-message-count='0')
       //     button.btn.btn-default(type='button' onclick='sendMessage()') Send
     ul#messageList
   div.messageSidebarCurtain(onclick='toggleNav()')
-            
+
+  script(src='https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.1/socket.io.js')
   script.
 
     // 메시지 목록 토글 스타일
@@ -24,16 +25,52 @@ div#messageSidebar(data-open='false', data-message-count='0')
       close: { 'width': '0' }
     }
 
+    var __service = {
+      
+      http: function () {
+        return {
+
+          sendMessage: function (message, callback) {
+            // validate
+            if ( !message ) { return }
+            if ( message.content.length <= 0 ) { return }
+          
+            $('#messageForm').find('input[name=content]').val('')
+            var messageCount = $('#messageSidebar').data('message-count')
+            $.post(url + '/message', message, callback)
+          },
+
+          loadMessage: function (messageCount, callback) {
+            var messageCount = $('#messageSidebar').data('message-count')
+            $.getJSON(url + '/message/' + messageCount, callback)
+          }
+
+        }
+      }
+
+    }
+
     // puclic function
     //  - 모듈 최초 로드시 호출된다.
     $(function () {
       // 부모 문서에서 특정 속성을 가진 요소에 이벤트를 바인딩한다.
       $('body').find('*[data-role="toggle-message-sidebar"]').on('click', toggleNav)
 
+      __service = __service.http
+
       // Initialization
       resize()
       loadMessage()
     })
+    
+    function initConnection () {
+      var socket = io('http://localhost')
+
+      socket.on('welcome', function(data) {
+        console.log(data)
+        socket.emit('sendMessage', { message: 'How are you?' })
+      })
+    }
 
     // puclic function
     //  - 메시지 목록을 열거나 닫는다.
@@ -50,7 +87,7 @@ div#messageSidebar(data-open='false', data-message-count='0')
 
     // service function
     //  - 메시지를 전송한다.
-    function sendMessage () {
+    function sendMessage (message) {
       var writer = $('#messageForm').find('input[name=writer]').val().trim() || 'Anonymous'
       var content = $('#messageForm').find('input[name=content]').val().trim()
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "moment": "^2.18.1",
     "mongoose": "^4.9.8",
     "request": "^2.81.0",
+    "socket.io": "^2.0.1",
     "urlencode": "^1.1.0"
   }
 }

--- a/router/message.js
+++ b/router/message.js
@@ -42,6 +42,7 @@ module.exports = (express) => {
             // pre-process
             message.seq = result ? result.seq + 1 : 1
             message.date = new Date()
+            message.formattedDate = moment(message.date).locale('ko').format('LLL')
             message.state = 1
 
             // save
@@ -72,14 +73,7 @@ module.exports = (express) => {
             .find({ state: 1 })
             .limit(loadCount)
             .sort({ date: -1 })
-            .then((result) => {
-                // post-process
-                result.forEach((message) => {
-                    message.formattedDate = moment(message.date).locale('ko').format('LLL')
-                })
-
-                onFurfilled(result)
-            })
+            .then(onFurfilled)
         })
     }
 

--- a/router/message.js
+++ b/router/message.js
@@ -1,5 +1,4 @@
-module.exports = (app) => {
-    let express = require('express')
+module.exports = (express) => {
     let moment = require('moment')
     let Message = require('../model/Message')
 
@@ -24,6 +23,10 @@ module.exports = (app) => {
                 totalCount: results[0],
                 messageList: results[1]
             })
+        })
+        .catch((error) => {
+            console.error(error)
+            res.setStatus(500).send(error)
         })
     })
 

--- a/socket.io/message.js
+++ b/socket.io/message.js
@@ -35,6 +35,7 @@ module.exports = (globalSocket) => {
                 // pre-process
                 message.seq = result ? result.seq + 1 : 1
                 message.date = new Date()
+                message.formattedDate = moment(message.date).locale('ko').format('LLL')
                 message.state = 1
 
                 // save
@@ -77,14 +78,7 @@ module.exports = (globalSocket) => {
             .find(findCondition)
             .limit(count)
             .sort({ date: -1 })
-            .then((result) => {
-                // post-process
-                result.forEach((message) => {
-                    message.formattedDate = moment(message.date).locale('ko').format('LLL')
-                })
-
-                onFurfilled(result)
-            })
+            .then(onFurfilled)
         })
     }
 

--- a/socket.io/message.js
+++ b/socket.io/message.js
@@ -1,11 +1,109 @@
-module.exports = (sockets) => {
-    sockets.on('connection', (socket) => {
-        // on connection established
-        socket.emit('welcome', { message: 'hello socket.io!' })
+module.exports = (globalSocket) => {
+    let moment = require('moment')
+    let Message = require('../model/Message')
 
-        // recieving message
-        socket.on('sendMessage', (data) => {
-            console.log("socket.on('sendMessage')", data)
+    const INITIAL_FETCH_SIZE = 10
+    const ADDITIONAL_FETCH_SIZE = 5
+
+    // on connection established
+    globalSocket.on('connection', (socket) => {
+        
+        // whenever recieve requestMessage
+        socket.on('requestMessage', (lastSeq) => {
+            Promise.all([
+                _countMessage(),
+                _getMessageList(lastSeq, ADDITIONAL_FETCH_SIZE)
+            ])
+            .then((results) => {
+                socket.emit('fetchMessage', {
+                    totalCount: results[0],
+                    messageList: results[1]
+                })
+            })
+            .catch((error) => {
+                console.error(error)
+                socket.emit('error', error)
+            })
+        })
+        
+        // whenever recieve sendMessage
+        socket.on('sendMessage', (message) => {
+            message = new Message(message)
+
+            _getMaxSeq()
+            .then((result) => {
+                // pre-process
+                message.seq = result ? result.seq + 1 : 1
+                message.date = new Date()
+                message.state = 1
+
+                // save
+                message
+                .save()
+                .then((saved) => {
+                    globalSocket.emit('newMessage', saved)
+                })
+            })
+            .catch((error) => {
+                console.error(error)
+                socket.emit('error', error)
+            })
+        })
+
+        // send initial messageList
+        Promise.all([
+            _countMessage(),
+            _getMessageList(0, INITIAL_FETCH_SIZE)
+        ])
+        .then((results) => {
+            socket.emit('fetchMessage', {
+                totalCount: results[0],
+                messageList: results[1]
+            })
+        })
+        .catch((error) => {
+            console.error(error)
+            socket.emit('error', error)
         })
     })
+
+    let _getMessageList = (lastSeq, count) => {
+        return new Promise((onFurfilled, onRejected) => {
+            // 이미 조회된 메시지가 존재 할 경우에만 seq 조건을 추가한다.
+            let findCondition = { state: 1 }
+            if ( lastSeq > 0 ) { findCondition.seq = { $lt: lastSeq } }
+
+            Message
+            .find(findCondition)
+            .limit(count)
+            .sort({ date: -1 })
+            .then((result) => {
+                // post-process
+                result.forEach((message) => {
+                    message.formattedDate = moment(message.date).locale('ko').format('LLL')
+                })
+
+                onFurfilled(result)
+            })
+        })
+    }
+
+    let _getMaxSeq = () => {
+        return new Promise((onFurfilled, onRejected) => {
+            Message
+            .findOne()
+            .sort({ seq: -1 })
+            .select('seq')
+            .then(onFurfilled)
+        })
+    }
+
+    let _countMessage = () => {
+        return new Promise((onFurfilled, onRejected) => {
+            Message
+            .count({ state: 1 })
+            .then(onFurfilled)
+        })
+    }
+
 }

--- a/socket.io/message.js
+++ b/socket.io/message.js
@@ -1,0 +1,11 @@
+module.exports = (sockets) => {
+    sockets.on('connection', (socket) => {
+        // on connection established
+        socket.emit('welcome', { message: 'hello socket.io!' })
+
+        // recieving message
+        socket.on('sendMessage', (data) => {
+            console.log("socket.on('sendMessage')", data)
+        })
+    })
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -42,7 +42,6 @@ tr{
     right: 0;
     background-color: #111;
     overflow-x: hidden;
-    padding-top: 25px;
     transition: 0.5s;
 }
 
@@ -64,7 +63,7 @@ tr{
 }
 
 .messageSidebar ul {
-    padding: 32px 16px 0px 16px;
+    padding: 60px 16px 0px 16px;
     overflow-y: auto;
 }
 

--- a/update-formatted-date.js
+++ b/update-formatted-date.js
@@ -2,24 +2,25 @@ var mongoose = require('mongoose')
 var moment = require('moment')
 var Message = require('./model/Message')
 
-let db = mongoose.connection;
-db.on('error', console.error);
-db.once('open', function(){
-    // CONNECTED TO MONGODB SERVER
-    console.log("Connected to mongod server");
-});
+// let db = mongoose.connection;
+// db.on('error', console.error);
+// db.once('open', function(){
+//     // CONNECTED TO MONGODB SERVER
+//     console.log("Connected to mongod server");
+// });
 mongoose.connect('mongodb://127.0.0.1/chartdb');
 
-try {
-  Message
-  .find()
-  .snapshot()
-  .then((result) => {
-    result.forEach((message) => {
-      message.formattedDate = moment(message.date).locale('ko').format('LLL')
-      message.save()
+Message
+.find()
+.snapshot()
+.then((result) => {
+  result.forEach((message) => {
+    message.formattedDate = moment(message.date).locale('ko').format('LLL')
+    message
+    .save()
+    .then((saved) => {
+      console.log('[%s] formattedDate updated from %s >> %s', saved.seq, message.formattedDate, saved.formattedDate)
     })
   })
-} catch (error) {
-  console.error(error)
-}
+})
+.catch(console.error)

--- a/update-formatted-date.js
+++ b/update-formatted-date.js
@@ -1,0 +1,25 @@
+var mongoose = require('mongoose')
+var moment = require('moment')
+var Message = require('./model/Message')
+
+let db = mongoose.connection;
+db.on('error', console.error);
+db.once('open', function(){
+    // CONNECTED TO MONGODB SERVER
+    console.log("Connected to mongod server");
+});
+mongoose.connect('mongodb://127.0.0.1/chartdb');
+
+try {
+  Message
+  .find()
+  .snapshot()
+  .then((result) => {
+    result.forEach((message) => {
+      message.formattedDate = moment(message.date).locale('ko').format('LLL')
+      message.save()
+    })
+  })
+} catch (error) {
+  console.error(error)
+}


### PR DESCRIPTION
기본적으로는 **http**로 통신하게 해뒀어요.

`index.jade` 파일 최하단 `include` 부분 보시면 아래와 같이 되어있을텐데
```
// include message module
include module/message-http
// include module/message-socket-io
```
이 부분에서 아래 두 줄의 주석을 아래와 같이 서로 바꿔주시면 **socket**으로 통신해요.
```
// include message module
// include module/message-http
include module/message-socket-io
```

`message-socket-io.jade` 를 호출하면 실시간으로 메시지 등록되는게 보일거예요.
데스크탑에서 여러 브라우저 동시에 띄워서 확인해봤어요.
익플에서 테스트해봤는데 일단 문제는 없는듯 하네요.

메시지 모듈에서 더 붙인다면
1. 메시지가 추가 될 때 좀 눈에 띄게 페이딩을 해주는거랑
2. 확인하지 않은 메시지가 있을 때 메시지 아이콘에 표시해주는

정도가 있겠네요 : )

## 중요
서버에 적용하실 때, 같이 추가한 `update-formatted-date.js` 한 번 돌려주세요.
``` sh
$ node update-formatted-date.js
```
돌리시고 콘솔출력 끝나면 바로 종료하셔도 됩니다.
이거 안 돌려주시면 **기존에 등록되었던 메시지들 등록일자 undefined로 뜰거예요** ㅋㅋ..

그럼 2만!